### PR TITLE
Update test_find_match_template_three to use set for result

### DIFF
--- a/tests/test_image_match_template.py
+++ b/tests/test_image_match_template.py
@@ -27,7 +27,7 @@ def test_find_match_template_one():
 def test_find_match_template_three():
     img_src = cv2.imread(os.path.join(img_dir, "html/browsers.png"))
     img_template = cv2.imread(os.path.join(img_dir, "html/browser_firefox.png"))
-    res = match_template(img_src, img_template)
+    res = set(match_template(img_src, img_template))
     assert len(res) == 3
     assert (321, 21) in res
     assert (478, 153) in res


### PR DESCRIPTION
Modified test_find_match_template_three to convert the match_template result to a set for O(1) lookup time and consistent test behavior. Dont change the behavior of the test.